### PR TITLE
add docker support.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,65 @@
+# Git
+.git
+.gitignore
+
+# Python
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+.pytest_cache
+.coverage
+.tox
+.venv
+venv/
+env/
+ENV/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Docker
+Dockerfile*
+.dockerignore
+
+# Documentation
+*.md
+docs/
+
+# Assets and examples
+assets/
+
+# Logs
+*.log
+logs/
+
+# Environment files
+.env
+.env.*
+
+# Cache directories
+.cache/
+.npm/
+node_modules/
+
+# Build artifacts
+build/
+dist/
+*.egg-info/
+
+# Temporary files
+tmp/
+temp/
+*.tmp
+
+# Lock files (keep uv.lock for dependency management)
+# uv.lock 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# 从 Docker Hub 拉取官方的 python 镜像，并指定标签为 3.13-slim 作为我们自定义镜像的基础。
+FROM python:3.13-slim
+
+# 设置容器内的环境变量。
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app
+
+# 安装系统依赖
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# 设置工作目录    
+WORKDIR /app
+
+# 复制依赖文件并安装
+COPY requirements.txt .
+
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
+    pip install --no-cache-dir -r requirements.txt
+
+# 复制应用程序代码
+COPY . .
+
+# 创建日志目录
+RUN mkdir -p /app/contest_trade/agents_workspace/logs
+
+# 创建并切换非 root 用户
+RUN useradd --create-home --shell /bin/bash appuser && \
+    chown -R appuser:appuser /app
+USER appuser
+


### PR DESCRIPTION
添加 Docker 支持，步骤如下。
1. 下载master分支源代码到本地。
`git clone https://github.com/FinStep-AI/ContestTrade.git`
2. 修改 `config.yaml` 中的相关配置。
3. 在本地构建docker 镜像，运行如下命令
`docker build -t <your-contesttrade-image-name> .`
4. 一条命令启动docker
`docker run --name <your-contesttrade-container-name> --rm -it <your-contesttrade-image-name> python -m cli.main run`
